### PR TITLE
Update Binder link.

### DIFF
--- a/repometadata/templates/README.md.jinja2
+++ b/repometadata/templates/README.md.jinja2
@@ -24,7 +24,7 @@
 | Coverage | [![codecov](https://codecov.io/gh/ubermag/{{ package }}/branch/master/graph/badge.svg?token=hcK4fofmrL)](https://codecov.io/gh/ubermag/{{ package }}) |
 | Documentation | [![Documentation](https://img.shields.io/badge/Docs-ubermag.github.io-blue)](https://ubermag.github.io/documentation/{{ package }}.html) |
 | YouTube | [![YouTube](https://img.shields.io/badge/YouTube-ubermag-blue)](https://www.youtube.com/channel/UC7MSqVQSMFV42R1jAYmKGLg) |
-| Binder | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ubermag/{{ package }}/stable?urlpath=lab/tree/docs/index.ipynb) |
+| Binder | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ubermag/{{ package }}/latest?urlpath=lab/tree/docs) |
 | Platforms | [![Platforms](https://anaconda.org/conda-forge/{{ package }}/badges/platforms.svg)](https://anaconda.org/conda-forge/{{ package }}) |
 | Downloads | [![Downloads](https://anaconda.org/conda-forge/{{ package }}/badges/downloads.svg)](https://anaconda.org/conda-forge/{{ package }}) |
 | License | [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) |


### PR DESCRIPTION
- To be merged after the release.
- After merge and update in all packages the individual `index.ipynb` notebooks can be deleted.