### PR TITLE
Same binder environment for all packages

### DIFF
--- a/repometadata/templates/binder/environment.yml.jinja2
+++ b/repometadata/templates/binder/environment.yml.jinja2
@@ -4,5 +4,5 @@ channels:
   - conda-forge
 
 dependencies:
-  - python==3.8
-  - {{ package }}
+  - python==3.10
+  - ubermag


### PR DESCRIPTION
This commit changes the binder environment.yaml to use the same environment for all notebooks of all repositories. With the update the whole ubermag package collection will be installed. After merging this requires running the metadata update to update all packages.

Reasons:
- Users might start with a notebook in e.g. `discretisedfield` from the website. While carrying on reading they might want to use additional packages, e.g. `micromagneticmodel` and `oommfc` that are currently not readily available. This deviates from our recommendation to always install `ubermag` to have all packages readily available.
- We use the same environment to define the required packages for the conda actions (which helps avoiding duplication). In `ubermagutil` the tests require `oommfc` but this is currently not available which causes the tests to fail.