### PR TITLE
Use new version of actions/checkout

### DIFF
--- a/repometadata/templates/.github/workflows/workflow.yml.jinja2
+++ b/repometadata/templates/.github/workflows/workflow.yml.jinja2
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Initialisation
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up conda
       uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
Can be merged and deployed to all repositories after the next release.